### PR TITLE
docs: add Ask DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![R-CMD-check](https://github.com/pjt222/jigsawR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/pjt222/jigsawR/actions/workflows/R-CMD-check.yaml)
 [![License: GPL-3](https://img.shields.io/badge/License-GPL--3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pjt222.github.io/jigsawR)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pjt222/jigsawR)
 
 <p align="center">
   <img src="man/figures/readme-hero.png" alt="jigsawR puzzle types" width="600">


### PR DESCRIPTION
Adds the DeepWiki badge to the README, linking to this repo's generated documentation at https://deepwiki.com/pjt222/jigsawR.

One line added; no existing line is modified or removed.

**Merge side effect.** `deploy-shiny.yml` has no path filter, so merging this docs-only change triggers a full shinyapps.io redeploy. Currently 4/4 green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MifHUz3JgFpRYWXZvhHLQh
